### PR TITLE
[feat] gpt 응답 streaming 적용

### DIFF
--- a/app/src/main/java/com/project/bonggong/ChatContract.kt
+++ b/app/src/main/java/com/project/bonggong/ChatContract.kt
@@ -13,14 +13,17 @@ interface ChatContract {
         fun showLoading()
         fun hideLoading()
 
-        // gpt 응답 표시
-        fun displayGPTResponse(response : Message)
+        // gpt 응답 표시 : non-streaming
+        fun displayGPTResponse(response: String)
+
+        // gpt 응답 조립 : streaming
+        fun enqueueTypingText(text: String)
 
         // 에러 메세지 표시
         fun showError(errorMessage: String)
     }
 
-    //
+    // 중간과정 -> 요청 전달, 반환, error 관리 등
     interface Presenter {
         // 사용자 메세지 처리
         fun onUserInput(input: String)

--- a/app/src/main/java/com/project/bonggong/model/GptApiRequest.kt
+++ b/app/src/main/java/com/project/bonggong/model/GptApiRequest.kt
@@ -1,5 +1,6 @@
 package com.project.bonggong.model
 
+import android.util.Log
 import com.project.bonggong.ChatContract
 import com.project.bonggong.api.data.CreateRunRequest
 import com.project.bonggong.api.data.CreateThreadAndRunRequest
@@ -111,6 +112,12 @@ class GptApiRequest: ChatContract.Model{
 
     // JSON 문자열에서 각 스트림 이벤트 추출
     private fun handleStreamEvent(jsonString: String, threadCallback: (String) -> Unit) {
+
+        // jsonString이 "[DONE]인 경우 즉시 종료 처리
+        if(jsonString == "[DONE]") {
+            Log.d(this.javaClass.simpleName, "Stream이 종료되었습니다.")
+            return
+        }
         val jsonObject = JSONObject(jsonString)
         val event = jsonObject.optString("object")
 

--- a/app/src/main/java/com/project/bonggong/model/Message.kt
+++ b/app/src/main/java/com/project/bonggong/model/Message.kt
@@ -1,7 +1,7 @@
 package com.project.bonggong.model
 
 data class Message(
-    val text: String,
+    var text: String,
     val profileImageRes: Int? = null,// 이미지 리소스 ID
     val isUser: Boolean = true,
     var isExpanded: Boolean = false // 더보기 토글

--- a/app/src/main/java/com/project/bonggong/presenter/ChatPresenter.kt
+++ b/app/src/main/java/com/project/bonggong/presenter/ChatPresenter.kt
@@ -2,8 +2,6 @@ package com.project.bonggong.presenter
 
 import android.util.Log
 import com.project.bonggong.ChatContract
-import com.project.bonggong.R
-import com.project.bonggong.model.Message
 
 class ChatPresenter(
     private var view: ChatContract.View,
@@ -37,8 +35,7 @@ class ChatPresenter(
 
             // 1-2. stream 방식
             model.createThreadAndRunStream(input, { deltaText ->
-                // 여기서 받아온 text(한 글자)를 화면에 뿌리는데, 별도의 처리 로직 필요
-                view.displayGPTResponse(Message(deltaText, R.drawable.bonggong_profile, false))
+                view.enqueueTypingText(deltaText)
             }, { error ->
                 view.showError(error.message ?: "알 수 없는 에러가 발생했습니다.")
             })
@@ -54,8 +51,7 @@ class ChatPresenter(
 
             // 2-2. stream 방식
             model.createRunStream(input, threadId!!, { deltaText ->
-                // 여기서 받아온 text(한 글자)를 화면에 뿌리는데, 별도의 처리 로직 필요
-                view.displayGPTResponse(Message(deltaText, R.drawable.bonggong_profile, false))
+                view.enqueueTypingText(deltaText)
             }, { error ->
                 view.showError(error.message ?: "알 수 없는 에러가 발생했습니다.")
             })
@@ -76,9 +72,7 @@ class ChatPresenter(
             Log.d("ChatPresenter.onUserInput", "봉공이봇 답변 : ${assistantMessage.toString()}")
 
             if (assistantMessage != null) {
-                view.displayGPTResponse(
-                    Message(assistantMessage, R.drawable.bonggong_profile, false)
-                )
+                view.displayGPTResponse(assistantMessage)
             } else {
                 view.showError("No assistant response found.")
             }

--- a/app/src/main/java/com/project/bonggong/view/ChatActivity.kt
+++ b/app/src/main/java/com/project/bonggong/view/ChatActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -25,6 +26,8 @@ import com.project.bonggong.presenter.ChatPresenter
 import com.project.bonggong.util.MarkdownProcessor
 
 class ChatActivity : AppCompatActivity(), ChatContract.View {
+
+    private val className = this.javaClass.simpleName
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var exampleQuestionsRecyclerView: RecyclerView
@@ -170,6 +173,7 @@ class ChatActivity : AppCompatActivity(), ChatContract.View {
     override fun showError(errorMessage: String) {
         // todo
         Toast.makeText(this, errorMessage, Toast.LENGTH_LONG).show()
+        Log.e(className, errorMessage)
     }
 
     // 키보드를 숨기는 메서드

--- a/app/src/main/java/com/project/bonggong/view/ChatActivity.kt
+++ b/app/src/main/java/com/project/bonggong/view/ChatActivity.kt
@@ -24,6 +24,13 @@ import com.project.bonggong.model.GptApiRequest
 import com.project.bonggong.model.Message
 import com.project.bonggong.presenter.ChatPresenter
 import com.project.bonggong.util.MarkdownProcessor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class ChatActivity : AppCompatActivity(), ChatContract.View {
 
@@ -38,7 +45,6 @@ class ChatActivity : AppCompatActivity(), ChatContract.View {
     private lateinit var exampleQuestionsAdapter: ExampleQuestionsAdapter
     private lateinit var clearButton: ImageButton
 
-
     // 메시지를 저장할 리스트 (Message 객체로)
     private val messages = mutableListOf<Message>()
     private val allExampleQuestions = listOf(
@@ -51,6 +57,21 @@ class ChatActivity : AppCompatActivity(), ChatContract.View {
         "인턴십 기회는 어디서 찾을 수 있나요?",
         "자기소개서는 어떻게 작성해야 하나요?"
     )
+
+    // 타이핑 효과를 위한 Coroutine Scope 정의
+    private val typingEffectScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    // 채널 선언 (타이핑 문자열을 순서대로 전송)
+    private val typingChannel = Channel<String>(Channel.UNLIMITED)
+
+    // Coroutine Scope에서 채널을 소비하여 순서대로 처리하는 코루틴 시작
+    init {
+        typingEffectScope.launch {
+            for (text in typingChannel) { // 채널에서 text를 순서대로 받음
+                applyTypingEffect(text) // 대기열에서 가져온 텍스트에 타이핑 효과 적용
+            }
+        }
+    }
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -161,19 +182,61 @@ class ChatActivity : AppCompatActivity(), ChatContract.View {
         TODO("Not yet implemented")
     }
 
-    override fun displayGPTResponse(response: Message) {
+    override fun displayGPTResponse(response: String) {
         // GPT 응답 메세지를 리스트에 추가
-        messages.add(response.copy(isExpanded = false)) //isExpanded 기본값 설정
+        messages.add(Message(response, R.drawable.bonggong_profile, false)) //isExpanded 기본값 설정
 
         // RecyclerView에 메세지 추가 및 화면 업데이트
         adapter.notifyItemInserted(messages.size - 1)
         recyclerView.scrollToPosition(messages.size - 1)
     }
 
+    override fun enqueueTypingText(text: String) {
+        // 새로 들어온 text를 채널에 전송
+        typingChannel.trySend(text)
+    }
+
+    // 실제 타이핑 효과를 실행하는 함수
+    private suspend fun applyTypingEffect(text: String) {
+        // GPT 메시지 초기화 (최초 한 번만)
+        if (messages.isEmpty() || messages.last().isUser) {
+            val typingMessage = Message("", R.drawable.bonggong_profile, false)
+            messages.add(typingMessage)
+            adapter.notifyItemInserted(messages.size - 1)
+        }
+
+        // 타이핑 효과
+        val messageIndex = messages.size - 1
+        val message = messages[messageIndex]
+
+        text.forEach { char ->
+            message.text += char
+            adapter.notifyItemChanged(messageIndex)
+            delay(15) // 타이핑 속도
+
+            // 마지막 줄에 스크롤을 맞추기 위해 offset 사용
+            scrollToBottom()
+        }
+    }
+
     override fun showError(errorMessage: String) {
         // todo
         Toast.makeText(this, errorMessage, Toast.LENGTH_LONG).show()
         Log.e(className, errorMessage)
+    }
+
+    private fun scrollToBottom(){
+        // 이후 약간의 오프셋을 부드럽게 스크롤하여 마지막 줄까지 보이도록 함
+        recyclerView.postDelayed({
+            val layoutManager = recyclerView.layoutManager as? LinearLayoutManager
+            layoutManager?.let {
+                val lastVisiblePosition = it.findLastCompletelyVisibleItemPosition()
+                // 마지막 메세지가 보이지 않을 때, smoothScroll
+                if (lastVisiblePosition != messages.size - 1) {
+                    recyclerView.smoothScrollBy(0, 200)
+                }
+            }
+        }, 300) // 첫 스크롤 후 약간의 지연시간을 두고 오프셋 적용 (스무스하게 연결)
     }
 
     // 키보드를 숨기는 메서드
@@ -199,6 +262,10 @@ class ChatActivity : AppCompatActivity(), ChatContract.View {
         adapter.notifyItemRangeRemoved(0, itemCount) // 0번 인덱스부터 모든 항목 제거
         Toast.makeText(this, "대화 내용이 초기화되었습니다.", Toast.LENGTH_SHORT).show()
     }
-
-
+    
+    // Activity가 파괴될 때, 코루틴 리소스 정리
+    override fun onDestroy() {
+        super.onDestroy()
+        typingEffectScope.cancel() // 액티비티 종료 시 코루틴 취소
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 기존에 gpt response messages에 추가해서 띄우기만 하는 작업을 coroutine을 사용해 한 글자씩 입력되는 것처럼 구현
- 에러 발생 시, Log 출력
- gpt streaming된 데이터 마지막인 [DONE]이 왔을 때, pasing 하지 않고 넘김 - `hotfix`

## 📸 스크린샷 (선택)
<!-- 공유하고 싶은 사진이 있다면 올려주세요!-->
<img src="https://github.com/user-attachments/assets/7b5faaf5-c593-4f31-abc0-43c933e92fc8" width="250px">


## 🫡 리뷰 요구사항 (선택)
> <!-- 리뷰어가 확인했으면 하는 내용을 중점으로 작성해주세요. -->
> ㅋㅋㅋㅋㅋㅋㅋㅋㅋ 개발할 때 재밌어서 올려봐요 ㅋㅋㅋㅋㅋ
> 
> <img src="https://github.com/user-attachments/assets/061e64b1-5829-4a03-82c4-3094278a2cbf" width="250px"> 봉공이_광공 ver_1 &nbsp;&nbsp;&nbsp; <img src="https://github.com/user-attachments/assets/ee7de3e5-e2a3-4c30-823f-f98e41096ade" width="250px">  봉공이_광공 ver_2


